### PR TITLE
avoid errors on invalid file characters

### DIFF
--- a/plugin/mru.vim
+++ b/plugin/mru.vim
@@ -187,7 +187,7 @@ endfunction
 
 function! s:load_oldfiles(mru)
    if !exists('s:oldfiles')
-      let s:oldfiles = map(copy(v:oldfiles), 'fnamemodify(expand(v:val), ":p")')
+      let s:oldfiles = map(copy(v:oldfiles), 'fnamemodify(v:val, ":p")')
    endif
    return filter(s:oldfiles, 'index(a:mru, v:val) < 0')
 endfunction
@@ -222,7 +222,7 @@ function! s:mru_fzf(fullscreen)
    let mru += s:load_oldfiles(mru)
 
    " ensure file exists
-   call filter(mru, 'filereadable(expand(v:val)) || isdirectory(expand(v:val))')
+   call filter(mru, 'filereadable(v:val) || isdirectory(v:val)')
 
    if exists('*FileFinder') " use Finder
       call FileFinder(mru, 'Recent files')


### PR DESCRIPTION
These expansions throw errors like

Trovato errore eseguendo function <SNR>179_mru_fzf[12]..<SNR>179_load_oldfiles:
riga    2:
E65: Riferimento all'indietro non consentito

when trying to expand invalid characters as happens in Vim in Git Bash trying to read windows paths.
Since  oldfiles likely does not store expansion characters to denote file paths, maybe these can be dropped (or made more robust by escaping?)